### PR TITLE
Remove unused R.string.app_name from library

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,2 @@
 <resources>
-    <string name="app_name">CalendarView</string>
 </resources>


### PR DESCRIPTION
This string seems to be unused and shipped as part of the library. This causes a resource merge conflict when using Bazel for building a dependent project instead of Gradle (and the consumer app module also has a string with the same name)