### PR TITLE
Regroup days for scrolling in week mode

### DIFF
--- a/library/src/main/java/com/kizitonwose/calendarview/CalendarView.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/CalendarView.kt
@@ -133,6 +133,7 @@ open class CalendarView : RecyclerView {
             if (field != value) {
                 field = value
                 pagerSnapHelper.attachToRecyclerView(if (value == ScrollMode.PAGED) this else null)
+                updateAdapterMonthConfig()
             }
         }
 
@@ -225,7 +226,7 @@ open class CalendarView : RecyclerView {
      */
     var wrappedPageHeightAnimationDuration = 200
 
-    private val pagerSnapHelper = CalenderPageSnapHelper()
+    private val pagerSnapHelper = CalendarPageSnapHelper()
 
     private var startMonth: YearMonth? = null
     private var endMonth: YearMonth? = null
@@ -438,6 +439,7 @@ open class CalendarView : RecyclerView {
                 outDateStyle,
                 inDateStyle,
                 maxRowCount,
+                scrollMode,
                 startMonth ?: return,
                 endMonth ?: return,
                 firstDayOfWeek ?: return,
@@ -804,6 +806,7 @@ open class CalendarView : RecyclerView {
             outDateStyle,
             inDateStyle,
             maxRowCount,
+            scrollMode,
             requireStartMonth(),
             requireEndMonth(),
             requireFirstDayOfWeek(),

--- a/library/src/main/java/com/kizitonwose/calendarview/model/MonthConfig.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/model/MonthConfig.kt
@@ -112,9 +112,8 @@ internal data class MonthConfig(
                 if (currentMonth != endMonth) currentMonth = currentMonth.next else break
             }
 
-            // Regroup data into 7 days (or 1 day for scrolling in week mode). Use toList() to create a copy of the ephemeral list.
-            val chunkSize = if (maxRowCount == 1 && scrollMode == ScrollMode.CONTINUOUS) 1 else 7
-            val allDaysGroup = allDays.chunked(chunkSize).toList()
+            // Regroup data into 7 days. Use toList() to create a copy of the ephemeral list.
+            val allDaysGroup = allDays.chunked(7).toList()
 
             val calendarMonths = mutableListOf<CalendarMonth>()
             val calMonthsCount = allDaysGroup.size roundDiv maxRowCount
@@ -172,11 +171,19 @@ internal data class MonthConfig(
                     }
                 }
 
-                calendarMonths.add(
-                    // numberOfSameMonth is the total number of all months and
-                    // indexInSameMonth is basically this item's index in the entire month list.
-                    CalendarMonth(startMonth, monthWeeks, calendarMonths.size, calMonthsCount)
-                )
+                val mothWeeksGroup =
+                    if (maxRowCount == 1 && scrollMode == ScrollMode.CONTINUOUS)
+                        // Regroup by 1 so we can scroll day by day in week mode
+                        monthWeeks.flatMap { it.chunked(1) }
+                    else monthWeeks
+
+                mothWeeksGroup.forEach { mothWeek ->
+                    calendarMonths.add(
+                        // numberOfSameMonth is the total number of all months and
+                        // indexInSameMonth is basically this item's index in the entire month list.
+                        CalendarMonth(startMonth, listOf(mothWeek), calendarMonths.size, calMonthsCount)
+                    )
+                }
             }
 
             return calendarMonths

--- a/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarPageSnapHelper.kt
+++ b/library/src/main/java/com/kizitonwose/calendarview/ui/CalendarPageSnapHelper.kt
@@ -5,7 +5,7 @@ import androidx.recyclerview.widget.OrientationHelper
 import androidx.recyclerview.widget.PagerSnapHelper
 import androidx.recyclerview.widget.RecyclerView
 
-internal class CalenderPageSnapHelper : PagerSnapHelper() {
+internal class CalendarPageSnapHelper : PagerSnapHelper() {
 
     /**
      * The default implementation of this method in [PagerSnapHelper.calculateDistanceToFinalSnap] uses the distance
@@ -23,6 +23,36 @@ internal class CalenderPageSnapHelper : PagerSnapHelper() {
             this[1] = if (layoutManager.canScrollVertically())
                 distanceToStart(targetView, getVerticalHelper(layoutManager)) else 0
         }
+    }
+
+    override fun findSnapView(layoutManager: RecyclerView.LayoutManager): View? {
+        if (layoutManager.canScrollHorizontally()) {
+            return findFirstView(layoutManager, getHorizontalHelper(layoutManager))
+        } else {
+            return findFirstView(layoutManager, getVerticalHelper(layoutManager))
+        }
+    }
+
+    private fun findFirstView(layoutManager: RecyclerView.LayoutManager?, helper: OrientationHelper): View? {
+        if (layoutManager == null) return null
+
+        val childCount = layoutManager.childCount
+        if (childCount == 0) return null
+
+        var absClosest = Integer.MAX_VALUE
+        var closestView: View? = null
+        val start = helper.startAfterPadding
+
+        for (i in 0 until childCount) {
+            val child = layoutManager.getChildAt(i)
+            val childStart = helper.getDecoratedStart(child)
+            val absDistanceToStart = Math.abs(childStart - start)
+            if (absDistanceToStart < absClosest) {
+                absClosest = absDistanceToStart
+                closestView = child
+            }
+        }
+        return closestView
     }
 
     private fun distanceToStart(targetView: View, helper: OrientationHelper): Int {

--- a/library/src/test/java/com/kizitonwose/calenderview/CalenderViewTests.kt
+++ b/library/src/test/java/com/kizitonwose/calenderview/CalenderViewTests.kt
@@ -1,9 +1,6 @@
 package com.kizitonwose.calenderview
 
-import com.kizitonwose.calendarview.model.DayOwner
-import com.kizitonwose.calendarview.model.InDateStyle
-import com.kizitonwose.calendarview.model.MonthConfig
-import com.kizitonwose.calendarview.model.OutDateStyle
+import com.kizitonwose.calendarview.model.*
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.DayOfWeek
@@ -20,6 +17,7 @@ class CalenderViewTests {
     private val may2019 = YearMonth.of(2019, 5)
     private val nov2019 = may2019.plusMonths(6)
     private val firstDayOfWeek = DayOfWeek.MONDAY
+    private val scrollMode = ScrollMode.CONTINUOUS
 
     @Test
     fun `test all month in date generation works as expected`() {
@@ -41,7 +39,7 @@ class CalenderViewTests {
     @Test
     fun `test first month in date generation works as expected`() {
         val months = MonthConfig.generateBoundedMonths(
-            may2019, nov2019, firstDayOfWeek, 6, InDateStyle.FIRST_MONTH, OutDateStyle.NONE
+            may2019, nov2019, firstDayOfWeek, 6, scrollMode, InDateStyle.FIRST_MONTH, OutDateStyle.NONE
         )
 
         // inDates are in the first month.
@@ -95,7 +93,7 @@ class CalenderViewTests {
         val maxRowCount = 3
         val months = MonthConfig.generateBoundedMonths(
             may2019, may2019.plusMonths(20),
-            firstDayOfWeek, maxRowCount, InDateStyle.ALL_MONTHS, OutDateStyle.END_OF_ROW
+            firstDayOfWeek, maxRowCount, scrollMode, InDateStyle.ALL_MONTHS, OutDateStyle.END_OF_ROW
         )
 
         assertTrue(months.all { it.weekDays.count() <= maxRowCount })
@@ -121,7 +119,7 @@ class CalenderViewTests {
         val maxRowCount = 3
         val months = MonthConfig.generateUnboundedMonths(
             may2019.minusMonths(40), may2019.plusMonths(50),
-            firstDayOfWeek, maxRowCount, InDateStyle.ALL_MONTHS, OutDateStyle.END_OF_GRID
+            firstDayOfWeek, maxRowCount, scrollMode, InDateStyle.ALL_MONTHS, OutDateStyle.END_OF_GRID
         )
 
         // The number of weeks in all CalendarMonth instances except the last one must match
@@ -137,7 +135,7 @@ class CalenderViewTests {
         val maxRowCount = 6
         MonthConfig.generateUnboundedMonths(
             YearMonth.of(2019, 2), YearMonth.of(2021, 2),
-            DayOfWeek.SUNDAY, maxRowCount, InDateStyle.ALL_MONTHS, OutDateStyle.END_OF_GRID
+            DayOfWeek.SUNDAY, maxRowCount, scrollMode, InDateStyle.ALL_MONTHS, OutDateStyle.END_OF_GRID
         )
         // No assertion necessary, as this particular range would throw an exception previously
         // when trying to build a day that is out of bounds (eg: December 32).


### PR DESCRIPTION
The goal:
Let users use snap helper of their choice in calendar's week mode

What was done:
I have regrouped days by 1 in case we are in week mode (maxRowCount = 1) and default ScrollMode.CONTINUOUS is used

Optionally:
I've also renamed Calend**e**rPageSnapHelper to Calend**a**rPageSnapHelper (typo fix)