### PR TITLE
Set JVM target to 1.8

### DIFF
--- a/buildSrc/src/main/java/com/kizitonwose/calendar/buildsrc/Dependencies.kt
+++ b/buildSrc/src/main/java/com/kizitonwose/calendar/buildsrc/Dependencies.kt
@@ -5,7 +5,7 @@ package com.kizitonwose.calendar.buildsrc
 import org.gradle.api.JavaVersion
 
 object Config {
-    val compatibleJavaVersion = JavaVersion.VERSION_11
+    val compatibleJavaVersion = JavaVersion.VERSION_1_8
 }
 
 object Android {


### PR DESCRIPTION
I started using the JVM toolchain feature of Gradle in a project, which aligned JVM target levels across all my Gradle tasks. This uncovered an issue with this dependency: it's targeting JVM level 11, while my project (and most Android projects) target JVM 1.8.

Looks like this is an easy thing to fix, so I created a PR! 