### PR TITLE
Change POM license name to 'MIT' and remove license URL for standard compliance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,7 @@ POM_SCM_URL=https://github.com/kizitonwose/calendar
 POM_SCM_CONNECTION=scm:git:git://github.com/kizitonwose/calendar.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/kizitonwose/calendar.git
 
-POM_LICENCE_NAME=MIT License
-POM_LICENCE_URL=https://github.com/kizitonwose/calendar/blob/main/LICENSE.md
+POM_LICENCE_NAME=MIT
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=kizitonwose


### PR DESCRIPTION
See https://github.com/cashapp/licensee/issues/137

`MIT` is the valid SPDX identifier, and specifying the URL breaks the Licensee plugin.

